### PR TITLE
Fix SWAP64 implementation to work on more platforms

### DIFF
--- a/src/CryptState.cpp
+++ b/src/CryptState.cpp
@@ -181,7 +181,7 @@ bool mumlib::CryptState::decrypt(const unsigned char *source, unsigned char *dst
 #define SHIFTBITS 63
 typedef uint64_t subblock;
 
-#define SWAP64(x) ({register uint64_t __out, __in = (x); __asm__("bswap %q0" : "=r"(__out) : "0"(__in)); __out;})
+#define SWAP64(x) (__builtin_bswap64(x))
 #define SWAPPED(x) SWAP64(x)
 
 typedef subblock keyblock[BLOCKSIZE];


### PR DESCRIPTION
This fixes SWAP64 implementation in CryptState.cpp to work on more platforms, specifically on ARM on the Raspberry Pi 2.

When compiling mumlib on the Raspbian Jessie 8 I received this error:

```
/home/pi/Development/mumpi/deps/mumlib/src/CryptState.cpp:184:104: error: invalid 'asm': invalid operand for code 'q'
 #define SWAP64(x) ({register uint64_t __out, __in = (x); __asm__("bswap %q0" : "=r"(__out) : "0"(__in)); __out;})
                                                                                                        ^
```

It seems that this particular bswap asm instruction is not available for ARM. After googling around, some folks reccomend using the GCC intrinsic `uint64_t __builtin_bswap64 (uint64_t x)`. This only works for GCC versions >= 4.2. I'm not much for figuring out the best cross-plat way here, but at least this works on both my ARM-based RaspberryPi and my x86_64 Linux desktop. 
